### PR TITLE
Enable macOS GitHub Action for release binary

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,37 @@
+# This is a basic workflow to help you get started with Actions
+
+name: macOS
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the $default-branch branch
+on:
+  push:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: macos-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    # Runs a set of commands using the runners shell
+    - name: Build
+      run: |
+        . tools/macos/activate-env 
+        get-qt
+        build-qt
+        ./build
+    - uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        automatic_release_tag: "latest_macos"
+        prerelease: true
+        title: "Latest macOS Build"
+        files: |
+          ../build-cryptoshark-x86_64/app/Cryptoshark.app/Contents/MacOS/Cryptoshark


### PR DESCRIPTION
Follow up #7 

This GitHub Action will release and publish the macOS binary for every push automatically.